### PR TITLE
add license generator, fixes extplug/extplug-cli#2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "babel-preset-extplug": "^2.0.0"
   },
   "scripts": {
-    "dir": "mkdir -p generators/app/templates",
-    "copy": "npm run dir && cp -r src/app/templates/* generators/app/templates/",
+    "dir": "mkdir -p generators/app/templates generators/readme/templates",
+    "copy": "npm run dir && cp -r src/app/templates/* generators/app/templates/ && cp -r src/readme/templates/* generators/readme/templates/",
     "babel": "babel --copy-files src --out-dir generators --ignore src/*/templates",
     "build": "npm run copy && npm run babel",
     "prepublish": "npm run build"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "generator-license": "^4.0.0",
     "object-assign": "^4.1.0",
-    "sort-keys": "^1.1.2",
     "yeoman-generator": "^0.24.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "yeoman-generator"
   ],
   "dependencies": {
+    "generator-license": "^4.0.0",
     "object-assign": "^4.1.0",
     "sort-keys": "^1.1.2",
     "yeoman-generator": "^0.24.1"

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -32,11 +32,6 @@ module.exports = Base.extend({
 
   writing() {
     this.fs.copyTpl(
-      this.templatePath('README.md'),
-      this.destinationPath('README.md'),
-      this.data
-    );
-    this.fs.copyTpl(
       this.templatePath('src/main.js'),
       this.destinationPath('src/main.js'),
       this.data
@@ -46,6 +41,12 @@ module.exports = Base.extend({
       this.destinationPath('package.json'),
       this.data
     );
+
+    this.composeWith('extplugin:readme', {
+      options: this.data,
+    }, {
+      local: require.resolve('../readme'),
+    });
   },
 
   install() {

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -1,5 +1,4 @@
 import { Base } from 'yeoman-generator';
-import sortKeys from 'sort-keys';
 import { camelize, slugify, titleize } from 'underscore.string';
 
 module.exports = Base.extend({

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -3,6 +3,11 @@ import sortKeys from 'sort-keys';
 import { camelize, slugify, titleize } from 'underscore.string';
 
 module.exports = Base.extend({
+  initializing() {
+    this.composeWith('license', {}, {
+      local: require.resolve('generator-license'),
+    });
+  },
   prompting() {
     return this.prompt([
       {
@@ -16,16 +21,12 @@ module.exports = Base.extend({
         name: 'description',
         message: 'One-line plugin description',
       },
-      {
-        type: 'input',
-        name: 'license',
-        message: 'License',
-        default: 'MIT',
-      },
     ]).then(answers => {
       this.data = answers;
       this.data.classname = camelize(this.data.pluginname);
       this.data.name = slugify(this.data.pluginname);
+
+      this.log('The following questions relate to which license you want to use.');
     });
   },
 

--- a/src/app/templates/README.md
+++ b/src/app/templates/README.md
@@ -29,8 +29,8 @@ The built plugin will be saved at `build/<%= name %>.js`.
 
 ## License
 
-[<%= license %>]
+See [LICENSE]
 
 [ExtPlug]: https://extplug.github.io/
 [ExtPlug CLI]: https://github.com/extplug/extplug-cli#readme
-[<%= license %>]: ./LICENSE
+[LICENSE]: ./LICENSE

--- a/src/app/templates/_package.json
+++ b/src/app/templates/_package.json
@@ -1,7 +1,7 @@
 {
   "name": "extplug-<%= name %>",
   "version": "0.0.0",
-  "license": "MIT",
+  "license": "",
   "description": "<%= description %>",
   "keywords": [
     "extplug-plugin"

--- a/src/readme/index.js
+++ b/src/readme/index.js
@@ -1,0 +1,42 @@
+import { Base } from 'yeoman-generator';
+import { camelize, slugify, titleize } from 'underscore.string';
+
+module.exports = Base.extend({
+  initializing() {
+    this.option('pluginname', {
+      type: String,
+      required: true,
+    });
+    this.option('name', {
+      type: String,
+      required: false,
+      defaults: null,
+    });
+    this.option('description', {
+      type: String,
+      required: false,
+      defaults: '',
+    });
+    this.option('license', {
+      type: String,
+      required: false,
+      defaults: 'LICENSE'
+    });
+  },
+
+  writing() {
+    const pkg = this.fs.readJSON(this.destinationPath('package.json'), {});
+    if (pkg.license) {
+      this.options.license = pkg.license;
+    }
+    this.fs.copyTpl(
+      this.templatePath('README.md'),
+      this.destinationPath('README.md'),
+      this.options
+    );
+  },
+
+  install() {
+    this.npmInstall();
+  },
+});

--- a/src/readme/templates/README.md
+++ b/src/readme/templates/README.md
@@ -29,8 +29,8 @@ The built plugin will be saved at `build/<%= name %>.js`.
 
 ## License
 
-See [LICENSE]
+[<%= license %>]
 
 [ExtPlug]: https://extplug.github.io/
 [ExtPlug CLI]: https://github.com/extplug/extplug-cli#readme
-[LICENSE]: ./LICENSE
+[<%= license %>]: ./LICENSE


### PR DESCRIPTION
This doesn't show the license name in the readme anymore though, should probably split this up into several generators so they can be ordered properly (i.e. generate package.json first, then run generator-license, then generate readme)
